### PR TITLE
Use classifiers to specify the license.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ setuptools.setup(
     author_email='grayson@graysonhead.net',
     url='https://github.com/graysonhead/mergedb',
     packages=setuptools.find_packages(),
-    license='GPL V3',
     install_requires=[
         'pyyaml>=5.1.0',
         'colorama>=0.4.1',
@@ -20,5 +19,8 @@ setuptools.setup(
         'console_scripts': [
             'mergedb = mergedb.__main__:main'
         ]
-    }
+    },
+    classifiers=[
+        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)'
+    ],
 )


### PR DESCRIPTION
Classifiers are a standard way of specifying a license, and make it easy
for automated tools to properly detect the license of the package.

The "license" field should only be used if the license has no
corresponding Trove classifier.